### PR TITLE
Initialize count to 1 to fix computed duration

### DIFF
--- a/src/translator/logic/CompumedicsTranslatorFactory.java
+++ b/src/translator/logic/CompumedicsTranslatorFactory.java
@@ -130,7 +130,7 @@ public class CompumedicsTranslatorFactory extends AbstractTranslatorFactory {
 		scoredEvent.appendChild(eventCategory);
 		scoredEvent.appendChild(eventConcept);
 		scoredEvent.appendChild(startElement);
-		int count = 0;
+		int count = 1;
 		for (int i = 1; i < stageList.getLength(); i++) {
 			String iStageValue = ((Element) stageList.item(i)).getTextContent();
 			if (iStageValue.compareTo(firstStageKey) == 0) {


### PR DESCRIPTION
The first element has a duration that's off by 30 seconds. It looks like the initial counter is starting incorrectly at 0 instead of at 1.

A file with two `<SleepStage>0</SleepStage><SleepStage>0</SleepStage>` would incorrectly have the duration set at 30 seconds instead of 60 seconds.
