### PR TITLE
Always include last stage in sleep event, fixes #4

### DIFF
--- a/src/translator/logic/CompumedicsTranslatorFactory.java
+++ b/src/translator/logic/CompumedicsTranslatorFactory.java
@@ -167,6 +167,7 @@ public class CompumedicsTranslatorFactory extends AbstractTranslatorFactory {
 		}
 		durationElement.appendChild(xmlRoot.createTextNode(Double.toString(count * 30)));
 		scoredEvent.appendChild(durationElement);
+		list.add(scoredEvent);
 		return list;
 	}
 


### PR DESCRIPTION
This is using Option 1 from Issue #4 and maintaining a 1-to-1 mapping for the Profusion to NSRR staging files.